### PR TITLE
Remove cloud taint check, replace with Pf9 annotation

### DIFF
--- a/controllers/node/node_controller.go
+++ b/controllers/node/node_controller.go
@@ -266,9 +266,9 @@ func (cnc *CloudNodeController) UpdateNodeStatus(ctx context.Context) error {
 	updateNodeFunc := func(piece int) {
 		node := nodes[piece].DeepCopy()
 		// Do not process nodes that are still tainted, those will be processed by syncNode()
-		cloudTaint := getCloudTaint(node.Spec.Taints)
-		if cloudTaint != nil {
-			klog.V(5).Infof("This node %s is still tainted. Will not process.", node.Name)
+		ngpcInitialized := getNGPCInitializedAnnotation(node)
+		if ngpcInitialized != "initialized" {
+			fmt.Printf("Node is not NGPC initialized, skipping: %s\n", ngpcInitialized)
 			return
 		}
 
@@ -355,9 +355,9 @@ func (cnc *CloudNodeController) reconcileNodeLabels(nodeName string) error {
 // UpdateNodeAddress updates the nodeAddress of a single node
 func (cnc *CloudNodeController) updateNodeAddress(ctx context.Context, node *v1.Node, instanceMetadata *cloudprovider.InstanceMetadata) {
 	// Do not process nodes that are still tainted
-	cloudTaint := getCloudTaint(node.Spec.Taints)
-	if cloudTaint != nil {
-		klog.V(5).Infof("This node %s is still tainted. Will not process.", node.Name)
+	ngpcInitialized := getNGPCInitializedAnnotation(node)
+	if ngpcInitialized != "initialized" {
+		fmt.Printf("Node is not NGPC initialized, skipping: %s\n", ngpcInitialized)
 		return
 	}
 
@@ -417,10 +417,9 @@ func (cnc *CloudNodeController) syncNode(ctx context.Context, nodeName string) e
 		return err
 	}
 
-	cloudTaint := getCloudTaint(curNode.Spec.Taints)
-	if cloudTaint == nil {
-		// Node object received from event had the cloud taint but was outdated,
-		// the node has actually already been initialized, so this sync event can be ignored.
+	ngpcInitialized := getNGPCInitializedAnnotation(curNode)
+	if ngpcInitialized == "initialized" {
+		fmt.Printf("Node has already been processed: %s\n", ngpcInitialized)
 		return nil
 	}
 
@@ -567,6 +566,13 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(
 		})
 	}
 
+	nodeModifiers = append(nodeModifiers, func(n *v1.Node) {
+		if n.Annotations == nil {
+			n.Annotations = map[string]string{}
+		}
+		n.Annotations["ngpc.pf9.io/cloudProvider"] = "initialized"
+	})
+
 	return nodeModifiers, nil
 }
 
@@ -574,7 +580,7 @@ func (cnc *CloudNodeController) getProviderID(ctx context.Context, node *v1.Node
 	if node.Spec.ProviderID != "" {
 		return node.Spec.ProviderID, nil
 	}
-
+	klog.Infof("getProviderID: node = %s\n", node.GetName())
 	if _, ok := cnc.cloud.InstancesV2(); ok {
 		// We don't need providerID when we call InstanceMetadata for InstancesV2
 		return "", nil
@@ -681,6 +687,18 @@ func excludeCloudTaint(taints []v1.Taint) []v1.Taint {
 		newTaints = append(newTaints, taint)
 	}
 	return newTaints
+}
+
+func getNGPCInitializedAnnotation(node *v1.Node) string {
+	if node.Annotations == nil {
+		return ""
+	}
+
+	annotation, ok := node.Annotations["ngpc.pf9.io/cloudProvider"]
+	if !ok {
+		return ""
+	}
+	return annotation
 }
 
 // ensureNodeExistsByProviderID checks if the instance exists by the provider id,


### PR DESCRIPTION
Currently setting the kubelet arg cloud-provider=external will involve non-trivial changes to our Qbert API, DB, pf9-kube agent, etc... plus backports, and require generating new RPMs and DU image.

In the interest of time, fork the cloud-provider module, and replace the taint check with an annotation of our own to mark the node as processed.

Essentially the logic is backwards:

 - Previously, if the taint was present, the provider ID and instance metadata was fetched and k8s Node object updated. Then in the node controller sync loop, if the taint was missing, the node was skipped. The taint essentially marked a new node as uninitialized
 - Now, we check for an annotation of our own. If annotation is missing, node controller assumes node is uninitialized and fetches providerID/metadata. If annotation is present and indicates "initialized", it skips the node

Once this is merged, I will update the go.mod in cloud-provider-rackspace to point to this commit/release branch